### PR TITLE
fix: correct CI workflow YAML structure and separate e2e-mock job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,16 @@ jobs:
           version: 9.15.9
       - run: pnpm install
       - run: pnpm test
+  e2e-mock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 9.15.9
+      - run: pnpm install
       - run: pnpm run test:e2e-mock
+  audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,16 @@ jobs:
           version: 9.15.9
       - run: pnpm install
       - run: pnpm test
+  e2e-mock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 9.15.9
+      - run: pnpm install
       - run: pnpm run test:e2e-mock
+  audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Fix broken YAML structure in `main.yml` and `pr.yml` where `audit` job's `runs-on` and `steps` were incorrectly nested inside `test` job
- Separate `e2e-mock` into its own job, running in parallel with `test`

## Test plan
- [x] Verify YAML syntax is valid
- [x] Confirm `e2e-mock` job runs independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)