### PR TITLE
chore: complete pnpm 11 upgrade in CI and engines

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: 9.15.9
+          version: 11.4.0
       - run: pnpm install
       - run: pnpm run lint
   test:
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: 9.15.9
+          version: 11.4.0
       - run: pnpm install
       - run: pnpm test
   e2e-mock:
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: 9.15.9
+          version: 11.4.0
       - run: pnpm install
       - run: pnpm run test:e2e-mock
   audit:
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: 9.15.9
+          version: 11.4.0
       - run: pnpm install
       - run: pnpm audit --audit-level moderate
   build:
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: 9.15.9
+          version: 11.4.0
       - run: pnpm install
       - run: node src/index.js --help
   coverage:
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: 9.15.9
+          version: 11.4.0
       - run: pnpm install
       - run: pnpm test -- --coverage
       - uses: codecov/codecov-action@v6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: 9.15.9
+          version: 11.4.0
       - run: pnpm install
       - run: pnpm run lint
   test:
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: 9.15.9
+          version: 11.4.0
       - run: pnpm install
       - run: pnpm test
   e2e-mock:
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: 9.15.9
+          version: 11.4.0
       - run: pnpm install
       - run: pnpm run test:e2e-mock
   audit:
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: 9.15.9
+          version: 11.4.0
       - run: pnpm install
       - run: pnpm audit --audit-level moderate
   build:
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: 9.15.9
+          version: 11.4.0
       - run: pnpm install
       - run: node src/index.js --help
   coverage:
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
         with:
-          version: 9.15.9
+          version: 11.4.0
       - run: pnpm install
       - run: pnpm test -- --coverage
       - uses: codecov/codecov-action@v6

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "packageManager": "pnpm@11.4.0",
   "engines": {
     "node": ">=16.0.0",
-    "pnpm": ">=9.0.0"
+    "pnpm": ">=11.0.0"
   },
   "scripts": {
     "lint": "eslint . --fix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,12 +237,14 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.2':
     resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
@@ -261,12 +263,14 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.2':
     resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.2':
     resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
@@ -841,24 +845,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+minimumReleaseAgeExclude:
+  - '@pkgr/core@0.3.6'
+  - eslint-plugin-prettier@5.5.6
+  - synckit@0.11.13


### PR DESCRIPTION
## Summary
- Update CI workflow pnpm versions from 9.15.9 to 11.4.0 (both main.yml and pr.yml)
- Bump `engines.pnpm` from `>=9.0.0` to `>=11.0.0` in package.json
- Regenerate lockfile for pnpm 11 format
- Add `pnpm-workspace.yaml` with `minimumReleaseAgeExclude` entries required by pnpm 11

Renovate PR #215 updated `packageManager` to `pnpm@11.4.0` but missed the CI workflow versions and engines field, causing a mismatch between the declared package manager and what CI actually installs.

## Test plan
- [ ] CI passes on this PR (lint, test, e2e-mock, audit, build, coverage)
- [ ] Verify pnpm 11.4.0 is used in all CI jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)